### PR TITLE
feat: support weth9 on ethereum and arbitrum1

### DIFF
--- a/registry/arbitrum-weth/CLAUDE_REPORT.md
+++ b/registry/arbitrum-weth/CLAUDE_REPORT.md
@@ -1,0 +1,48 @@
+# CLAUDE_REPORT.md
+
+## Arbitrum WETH ERC-7730 Descriptor Generation Report
+
+### Summary
+Successfully generated an ERC-7730 descriptor for the WETH (Wrapped Ether) contract on Arbitrum One at address `0x82aF49447D8a07e3bd95BD0d56f35241523fBab1` (chain ID 42161).
+
+### What Was Done
+1. Validated the contract exists and is verified on Arbiscan
+2. Identified this is a TransparentUpgradeableProxy contract with implementation at `0x8b194beae1d3e0788a1a35173978001acdfba668` (aeWETH)
+3. Retrieved the implementation ABI manually since the proxy ABI doesn't contain the token functions
+4. Created a custom descriptor with all relevant WETH functions including Arbitrum-specific ones
+5. Successfully validated with `erc7730 lint` (note: proxy validation warning is expected)
+6. Formatted with `erc7730 format`
+
+### Key Features Included
+- **Functions covered**: 
+  - Standard: `approve`, `transfer`, `transferFrom`, `deposit`, `withdraw`
+  - Arbitrum-specific: `depositTo`, `withdrawTo` (allows wrapping/unwrapping for other addresses)
+- **Proper intents**: Each function has a clear, user-friendly intent description
+- **Token amount formatting**: All WETH amounts display with proper token formatting
+- **Address name resolution**: Addresses show with appropriate types (EOA, wallet, contract)
+- **Native ETH handling**: The `deposit()` and `depositTo()` functions correctly handle native ETH value display
+
+### Technical Details
+- This is a proxy contract, so the linter shows a proxy warning (this is normal and expected)
+- The contract includes additional functions for the Arbitrum bridge (`bridgeMint`, `bridgeBurn`, etc.) which were not included in the display formats as they are typically admin-only functions
+- The implementation includes EIP-2612 permit functionality which was not included in this initial descriptor
+
+### Tasks for Manual Review
+1. **Metadata verification**: Please verify the owner field - currently set to "Arbitrum" but may need to be more specific
+2. **Website URL**: Currently using "https://arbitrum.io" - verify if there's a more specific URL for Arbitrum WETH
+3. **Additional functions**: Review if any of these should be included:
+   - `permit` - EIP-2612 permit functionality
+   - `increaseAllowance`/`decreaseAllowance` - Safe allowance modification functions
+   - Bridge-specific functions (`bridgeMint`, `bridgeBurn`) if they're user-facing
+4. **Multi-deployment addresses**: Verify if this WETH contract is deployed at the same address on other Arbitrum chains (Nova, Sepolia, etc.)
+5. **Test transactions**: Test this descriptor with actual Arbitrum WETH transactions to ensure the display is clear
+
+### Important Notes
+- This is a **DRAFT** descriptor meant as a starting point
+- Manual review and testing are required before production use
+- The descriptor follows ERC-7730 v1 schema and passes all validation checks
+- The ABI is embedded directly rather than referenced via URL
+- This contract is a proxy, so updates to the implementation would need to be monitored
+
+### File Location
+- Generated descriptor: `/registry/arbitrum-weth/calldata-WETH-Arbitrum.json`

--- a/registry/arbitrum-weth/calldata-WETH-Arbitrum.json
+++ b/registry/arbitrum-weth/calldata-WETH-Arbitrum.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "WETH-Arbitrum",
+    "contract": {
+      "deployments": [{ "chainId": 42161, "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" }],
+      "abi": [
+        {
+          "inputs": [
+            { "internalType": "address", "name": "spender", "type": "address" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" }
+          ],
+          "name": "approve",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        { "inputs": [], "name": "deposit", "outputs": [], "stateMutability": "payable", "type": "function" },
+        {
+          "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+          "name": "depositTo",
+          "outputs": [],
+          "stateMutability": "payable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "recipient", "type": "address" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" }
+          ],
+          "name": "transfer",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "sender", "type": "address" },
+            { "internalType": "address", "name": "recipient", "type": "address" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" }
+          ],
+          "name": "transferFrom",
+          "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [{ "internalType": "uint256", "name": "amount", "type": "uint256" }],
+          "name": "withdraw",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            { "internalType": "address", "name": "account", "type": "address" },
+            { "internalType": "uint256", "name": "amount", "type": "uint256" }
+          ],
+          "name": "withdrawTo",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Arbitrum",
+    "info": { "legalName": "Arbitrum Wrapped Ether", "url": "https://arbitrum.io" },
+    "constants": { "wethAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" }
+  },
+  "display": {
+    "formats": {
+      "approve(address,uint256)": {
+        "intent": "authorize WETH spending",
+        "fields": [
+          {
+            "label": "Spender",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local"] },
+            "path": "#.spender"
+          },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.amount", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.spender", "#.amount"],
+        "excluded": []
+      },
+      "transfer(address,uint256)": {
+        "intent": "transfer WETH",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "path": "#.recipient"
+          },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.amount", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.recipient", "#.amount"],
+        "excluded": []
+      },
+      "transferFrom(address,address,uint256)": {
+        "intent": "transfer WETH on behalf",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] },
+            "path": "#.sender"
+          },
+          {
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] },
+            "path": "#.recipient"
+          },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.amount", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.sender", "#.recipient", "#.amount"],
+        "excluded": []
+      },
+      "deposit()": {
+        "intent": "wrap ETH to WETH",
+        "fields": [
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "@.value",
+            "params": { "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000" }
+          }
+        ],
+        "required": ["@.value"],
+        "excluded": []
+      },
+      "depositTo(address)": {
+        "intent": "wrap ETH to WETH for recipient",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] },
+            "path": "#.account"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "@.value",
+            "params": { "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000" }
+          }
+        ],
+        "required": ["#.account", "@.value"],
+        "excluded": []
+      },
+      "withdraw(uint256)": {
+        "intent": "unwrap WETH to ETH",
+        "fields": [
+          { "label": "Amount", "format": "tokenAmount", "path": "#.amount", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.amount"],
+        "excluded": []
+      },
+      "withdrawTo(address,uint256)": {
+        "intent": "unwrap WETH to ETH for recipient",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] },
+            "path": "#.account"
+          },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.amount", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.account", "#.amount"],
+        "excluded": []
+      }
+    }
+  }
+}

--- a/registry/weth/CLAUDE_REPORT.md
+++ b/registry/weth/CLAUDE_REPORT.md
@@ -1,0 +1,37 @@
+# CLAUDE_REPORT.md
+
+## WETH9 ERC-7730 Descriptor Generation Report
+
+### Summary
+Successfully generated an ERC-7730 descriptor for the WETH9 (Wrapped Ether) contract at address `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2` on Ethereum mainnet (chain ID 1).
+
+### What Was Done
+1. Validated the contract exists and is verified on Etherscan (confirmed as WETH9)
+2. Generated initial descriptor using `erc7730 generate` command
+3. Enhanced the descriptor with proper metadata, intents, and display formatting
+4. Fixed validation issues (changed `nativeCurrency` to `nativeCurrencyAddress`)
+5. Successfully validated with `erc7730 lint`
+6. Formatted with `erc7730 format`
+
+### Key Features Included
+- **Functions covered**: `approve`, `transfer`, `transferFrom`, `deposit`, `withdraw`
+- **Proper intents**: Each function has a clear, user-friendly intent description
+- **Token amount formatting**: All WETH amounts display with proper token formatting
+- **Address name resolution**: Addresses show with appropriate types (EOA, wallet, contract)
+- **Native ETH handling**: The `deposit()` function correctly handles native ETH value display
+
+### Tasks for Manual Review
+1. **Metadata verification**: Please verify the owner and legal name fields are correct
+2. **Website URL**: The URL "https://weth.io" should be verified (this may need updating)
+3. **View functions**: The read-only functions (`name`, `symbol`, `decimals`, `balanceOf`, `totalSupply`, `allowance`) were not included in display formats as they don't require transaction signing
+4. **Multi-chain deployments**: This descriptor only includes Ethereum mainnet. If WETH9 is deployed on other chains with the same address, those deployments should be added
+5. **Test transactions**: It's recommended to test this descriptor with actual WETH9 transactions to ensure the display is clear and accurate
+
+### Important Notes
+- This is a **DRAFT** descriptor meant as a starting point
+- Manual review and testing are required before production use
+- The descriptor follows ERC-7730 v1 schema and passes all validation checks
+- The ABI is embedded directly in the file rather than referenced via URL
+
+### File Location
+- Generated descriptor: `/registry/weth/calldata-WETH9.json`

--- a/registry/weth/calldata-WETH9.json
+++ b/registry/weth/calldata-WETH9.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "../../specs/erc7730-v1.schema.json",
+  "context": {
+    "$id": "WETH9",
+    "contract": {
+      "deployments": [{ "chainId": 1, "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" }],
+      "abi": [
+        {
+          "type": "function",
+          "name": "name",
+          "inputs": [],
+          "outputs": [{ "name": "", "type": "string" }],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "approve",
+          "inputs": [{ "name": "guy", "type": "address" }, { "name": "wad", "type": "uint256" }],
+          "outputs": [{ "name": "", "type": "bool" }],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "totalSupply",
+          "inputs": [],
+          "outputs": [{ "name": "", "type": "uint256" }],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "transferFrom",
+          "inputs": [{ "name": "src", "type": "address" }, { "name": "dst", "type": "address" }, { "name": "wad", "type": "uint256" }],
+          "outputs": [{ "name": "", "type": "bool" }],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "withdraw",
+          "inputs": [{ "name": "wad", "type": "uint256" }],
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "decimals",
+          "inputs": [],
+          "outputs": [{ "name": "", "type": "uint8" }],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "balanceOf",
+          "inputs": [{ "name": "", "type": "address" }],
+          "outputs": [{ "name": "", "type": "uint256" }],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "symbol",
+          "inputs": [],
+          "outputs": [{ "name": "", "type": "string" }],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "transfer",
+          "inputs": [{ "name": "dst", "type": "address" }, { "name": "wad", "type": "uint256" }],
+          "outputs": [{ "name": "", "type": "bool" }],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false
+        },
+        {
+          "type": "function",
+          "name": "deposit",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "payable",
+          "constant": false,
+          "payable": true
+        },
+        {
+          "type": "function",
+          "name": "allowance",
+          "inputs": [{ "name": "", "type": "address" }, { "name": "", "type": "address" }],
+          "outputs": [{ "name": "", "type": "uint256" }],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "WETH9",
+    "info": { "legalName": "Wrapped Ether", "url": "https://weth.io" },
+    "constants": { "wethAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" }
+  },
+  "display": {
+    "formats": {
+      "approve(address,uint256)": {
+        "intent": "authorize WETH spending",
+        "fields": [
+          { "label": "Spender", "format": "addressName", "params": { "types": ["contract"], "sources": ["local"] }, "path": "#.guy" },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.wad", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.guy", "#.wad"],
+        "excluded": []
+      },
+      "transfer(address,uint256)": {
+        "intent": "transfer WETH",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet"], "sources": ["local", "ens"] },
+            "path": "#.dst"
+          },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.wad", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.dst", "#.wad"],
+        "excluded": []
+      },
+      "transferFrom(address,address,uint256)": {
+        "intent": "transfer WETH on behalf",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] },
+            "path": "#.src"
+          },
+          {
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "wallet", "contract"], "sources": ["local", "ens"] },
+            "path": "#.dst"
+          },
+          { "label": "Amount", "format": "tokenAmount", "path": "#.wad", "params": { "token": "$.metadata.constants.wethAddress" } }
+        ],
+        "required": ["#.src", "#.dst", "#.wad"],
+        "excluded": []
+      },
+      "deposit()": {
+        "intent": "wrap ETH to WETH",
+        "fields": [
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "@.value",
+            "params": { "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000" }
+          }
+        ],
+        "required": ["@.value"],
+        "excluded": []
+      },
+      "withdraw(uint256)": {
+        "intent": "unwrap WETH to ETH",
+        "fields": [{ "label": "Amount", "format": "tokenAmount", "path": "#.wad", "params": { "token": "$.metadata.constants.wethAddress" } }],
+        "required": ["#.wad"],
+        "excluded": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
output for
```
> /draft 1:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
```
and
```
> /draft 42161:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1
```